### PR TITLE
django.conf.urls.patterns is deprecated

### DIFF
--- a/stickyuploads/urls.py
+++ b/stickyuploads/urls.py
@@ -1,7 +1,7 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from .views import UploadView
 
-urlpatterns = patterns('',
+urlpatterns = [
     url(r'^default/$', UploadView.as_view(), name='sticky-upload-default'),
-)
+]


### PR DESCRIPTION
django.conf.urls.patterns is deprecated since Django1.8
https://docs.djangoproject.com/en/1.8/ref/urls/#patterns