### PR TITLE
Fixed #16 -- Fixed Django1.10 deprecations and updated tox.ini

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,10 @@ python:
 
 env:
   - TOXENV=py27-1.4.X
-  - TOXENV=py27-1.5.X,py32-1.5.X
-  - TOXENV=py27-1.6.X,py32-1.6.X
-  - TOXENV=py27-1.7.X,py32-1.7.X
-  - TOXENV=py27-1.8.X,py32-1.8.X
+  - TOXENV=py27-1.5.X,py34-1.5.X
+  - TOXENV=py27-1.6.X,py34-1.6.X
+  - TOXENV=py27-1.7.X,py34-1.7.X
+  - TOXENV=py27-1.8.X,py34-1.8.X
 
 install:
   - pip install "tox>=1.8,<2.0"

--- a/example/example/urls.py
+++ b/example/example/urls.py
@@ -1,12 +1,12 @@
 from django.conf import settings
-from django.conf.urls import patterns, include, url
+from django.conf.urls import include, url
 from django.conf.urls.static import static
 from django.contrib import admin
 
 admin.autodiscover()
 
 
-urlpatterns = patterns('',
+urlpatterns = [
     # Examples:
     # url(r'^$', 'example.views.home', name='home'),
     # url(r'^example/', include('example.foo.urls')),
@@ -20,4 +20,4 @@ urlpatterns = patterns('',
     url(r'^login/$', 'django.contrib.auth.views.login', {'template_name': 'login.html'}, name='login'),
     url(r'^logout/$', 'django.contrib.auth.views.logout_then_login', name='logout'),
     url(r'^$', 'main.views.home', name='home'),
-) + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/stickyuploads/tests/test_forms.py
+++ b/stickyuploads/tests/test_forms.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
 
 from django.core.files.uploadedfile import SimpleUploadedFile
-from django.utils import unittest
+import unittest
 
 from mock import patch
 

--- a/stickyuploads/tests/test_integration.py
+++ b/stickyuploads/tests/test_integration.py
@@ -73,7 +73,7 @@ class ExampleForm(forms.ModelForm):
         }
 
 
-class ModelFormIntegrationTestCase(TempFileMixin, FormIntegrationMixin, SimpleTestCase):
+class ModelFormIntegrationTestCase(TempFileMixin, FormIntegrationMixin, TestCase):
     """Using StickyUploadWidget in a ModelForm class."""
 
     form_class = ExampleForm

--- a/stickyuploads/tests/test_utils.py
+++ b/stickyuploads/tests/test_utils.py
@@ -3,13 +3,13 @@ from __future__ import unicode_literals
 import os
 import shutil
 import tempfile
+import unittest
 
 from django.conf import settings
 from django.core import signing
 from django.core.files import File
 from django.core.files.storage import FileSystemStorage, DefaultStorage
 from django.test import SimpleTestCase
-from django.utils import unittest
 
 from .. import utils
 from .base import TempFileMixin

--- a/stickyuploads/tests/urls.py
+++ b/stickyuploads/tests/urls.py
@@ -1,6 +1,6 @@
-from django.conf.urls import patterns, include, url
+from django.conf.urls import include, url
 
 
-urlpatterns = patterns('',
+urlpatterns = [
     url(r'^sticky-uploads/', include('stickyuploads.urls')),
-)
+]

--- a/tox.ini
+++ b/tox.ini
@@ -1,17 +1,18 @@
 [tox]
-envlist = {py27,py32}-{1.8,1.7,1.6,1.5}.X,{py27}-1.4.X,docs
+envlist = {py27,py34}-{1.9,1.8,1.7,1.6,1.5}.X,{py27}-1.4.X,docs
 
 [testenv]
 basepython =
     py27: python2.7
-    py32: python3.2
+    py34: python3.4
 deps =
     mock
     1.4.X: Django>=1.4,<1.5
     1.5.X: Django>=1.5,<1.6
     1.6.X: Django>=1.6,<1.7
     1.7.X: Django>=1.7,<1.8
-    1.8.X: Django>=1.8,<1.9 
+    1.8.X: Django>=1.8,<1.9
+    1.9.X: Django>=1.9,<1.10
 commands = {envpython} setup.py test
 
 [testenv:docs]


### PR DESCRIPTION
Addresses the issue raised in #16 as well as a few additional deprecations, primarily in the test suite.  I also took the liberty of updating the tox file to include Django1.9 (and replaced Python3.2 with Python3.4).
