### PR TITLE
Send form errors in the JSON response

### DIFF
--- a/stickyuploads/tests/test_views.py
+++ b/stickyuploads/tests/test_views.py
@@ -60,4 +60,4 @@ class UploadViewTestCase(TempFileMixin, TestCase):
             response = self.client.post(self.url, data)
         self.assertEqual(response.status_code, 200)
         result = json.loads(response.content.decode('utf-8'))
-        self.assertEqual(result, {'is_valid': False})
+        self.assertEqual(result, {'is_valid': False, 'errors': {'upload': ['The submitted file is empty.']}})

--- a/stickyuploads/views.py
+++ b/stickyuploads/views.py
@@ -26,7 +26,10 @@ class UploadView(View):
                 info = form.stash(storage, self.request.path)
                 result.update(info)
             else:
-                result['is_valid'] = False
+                result.update({
+                    'is_valid': False,
+                    'errors': form.errors,
+                })
             return HttpResponse(json.dumps(result), content_type='application/json')
         else:
             return HttpResponseForbidden()


### PR DESCRIPTION
This will make it easy to display errors in the front-end when we use custom form with some validation (for example file size or virus checking).

I know that validation need to be in real form, but by this way errors can be shown to the user before submit. For security validation need to be doubled (On the main form and on the custom upload form) but will improve user experience.

For now I was not made any changes in the JavaScript to show the errors sent from the back-end. This can be made later.