### PR TITLE
Put files in random directories to prevent filename collisions

### DIFF
--- a/stickyuploads/forms.py
+++ b/stickyuploads/forms.py
@@ -1,4 +1,5 @@
 """Form logic for background saving uploaded files."""
+import os
 
 from django import forms
 
@@ -16,7 +17,7 @@ class UploadForm(forms.Form):
         if self.is_valid():
             upload = self.cleaned_data['upload']
             name = storage.save(upload.name, upload)
-            result['filename'] = name
+            result['filename'] = os.path.basename(name)
             try:
                 result['url'] = storage.url(name)
             except NotImplementedError:

--- a/stickyuploads/storage.py
+++ b/stickyuploads/storage.py
@@ -1,3 +1,4 @@
+import os
 import tempfile
 
 from django.core.files.storage import FileSystemStorage
@@ -13,3 +14,17 @@ class TempFileSystemStorage(FileSystemStorage):
     def url(self, name):
         """Files are not accessable via url."""
         raise NotImplementedError()
+
+    def get_available_name(self, name, max_length=None):
+        """Return relative path to name placed in random directory"""
+        tempdir = tempfile.mkdtemp(dir=self.base_location)
+        name = os.path.join(
+            os.path.basename(tempdir),
+            os.path.basename(name),
+        )
+        method = super(TempFileSystemStorage, self).get_available_name
+        try:
+            return method(name, max_length=max_length)
+        except TypeError:
+            # Django < 1.8
+            return method(name)

--- a/stickyuploads/tests/test_views.py
+++ b/stickyuploads/tests/test_views.py
@@ -33,13 +33,14 @@ class UploadViewTestCase(TempFileMixin, TestCase):
             response = self.client.post(self.url, data)
         self.assertEqual(response.status_code, 200)
         result = json.loads(response.content.decode('utf-8'))
-        storage = TempFileSystemStorage()
         filename = os.path.basename(self.temp_name)
+        # We can't test stored value because there are unknowns
+        self.assertIn('stored', result)
         expected = {
             'is_valid': True,
             'filename': filename,
             'url': None,
-            'stored': serialize_upload(filename, storage, self.url),
+            'stored': result['stored'],
         }
         self.assertEqual(result, expected)
 


### PR DESCRIPTION
Fixes #14

This will also helps in security because will make file name guessing harder.