### PR TITLE
Use strict and set context to $.ajax callbacks

### DIFF
--- a/stickyuploads/static/stickyuploads/js/django-uploader.js
+++ b/stickyuploads/static/stickyuploads/js/django-uploader.js
@@ -12,6 +12,7 @@
 */
 var djUp = djUp || jQuery;
 (function ($, window, document, undefined) {
+    "use strict";
     var pluginName = "djangoUploader",
         defaults = {
             url: "",
@@ -83,16 +84,17 @@ var djUp = djUp || jQuery;
                     type: "POST",
                     data: formData,
                     crossDomain: false,
-                    beforeSend: $.proxy(this._add_csrf_header, this),
+                    context: this,
+                    beforeSend: this._add_csrf_header,
                     processData: false,
                     contentType: false,
-                    xhr: $.proxy(this.xhr, this)
+                    xhr: this.xhr
                 }).done(
-                    $.proxy(this.done, this)
+                    this.done
                 ).fail(
-                    $.proxy(this.fail, this)
+                    this.fail
                 ).always(
-                    $.proxy(this.always, this)
+                    this.always
                 );
             }
         },

--- a/stickyuploads/static/stickyuploads/js/django-uploader.js
+++ b/stickyuploads/static/stickyuploads/js/django-uploader.js
@@ -59,8 +59,8 @@ var djUp = djUp || jQuery;
         init: function () {
             this.processing = false;
             this.options.url = this.$element.data("uploadUrl");
-            this.$hidden = $(":input[type=hidden][name=_" + this.$element.attr("name")  + "]");
-            this.$form = this.$element.parents("form").eq(0);
+            this.$form = this.$element.closest("form");
+            this.$hidden = this.$form.find(":input[type=hidden][name=_" + this.$element.attr("name")  + "]");
             if (this.enabled()) {
                 this.$element.on("change", $.proxy(this.change, this));
                 this.$form.on("submit", $.proxy(this.submit, this));

--- a/stickyuploads/static/stickyuploads/js/django-uploader.js
+++ b/stickyuploads/static/stickyuploads/js/django-uploader.js
@@ -60,7 +60,7 @@ var djUp = djUp || jQuery;
             this.processing = false;
             this.options.url = this.$element.data("uploadUrl");
             this.$form = this.$element.closest("form");
-            this.$hidden = this.$form.find(":input[type=hidden][name=_" + this.$element.attr("name")  + "]");
+            this.$hidden = this.$form.find("input[type=hidden][name=_" + this.$element.attr("name")  + "]");
             if (this.enabled()) {
                 this.$element.on("change", $.proxy(this.change, this));
                 this.$form.on("submit", $.proxy(this.submit, this));


### PR DESCRIPTION
- "use strict" on top for using JavaScript strict mode.
- Set `context` in `$.ajax` options. Then there is no need of using `$.proxy` for callbacks
- Find form with `closest` instead of `parents`
- Find hidden input by traversing `input` elements in the form, not in the whole DOM